### PR TITLE
Encrypt read key

### DIFF
--- a/src/Application/Authorisation/State.elm
+++ b/src/Application/Authorisation/State.elm
@@ -61,7 +61,8 @@ allow model =
             ( model
             , Ports.linkApp
                 { attenuation = attenuation
-                , did = context.didWrite
+                , didWrite = context.didWrite
+                , didExchange = context.didExchange
                 , lifetimeInSeconds = context.lifetimeInSeconds
                 }
             )

--- a/src/Application/Ports.elm
+++ b/src/Application/Ports.elm
@@ -22,7 +22,8 @@ port linkApp :
             { capability : String
             , resource : ( String, String )
             }
-    , did : String
+    , didWrite : String
+    , didExchange : String
     , lifetimeInSeconds : Int
     }
     -> Cmd msg

--- a/src/Javascript/Main.js
+++ b/src/Javascript/Main.js
@@ -198,8 +198,8 @@ async function createAccount(args) {
 // LINK
 // ----
 
-async function linkApp({ did, attenuation, lifetimeInSeconds }) {
-  const audience = did
+async function linkApp({ didWrite, didExchange, attenuation, lifetimeInSeconds }) {
+  const audience = didWrite
   const issuer = await sdk.did.write()
   const proof = await localforage.getItem("ucan")
 
@@ -226,7 +226,12 @@ async function linkApp({ did, attenuation, lifetimeInSeconds }) {
   })
 
   const ucans = [ await ucanPromise ]
-  const readKey = await myReadKey()
+
+  // encrypt symmetric key
+  const plainTextReadKey = await myReadKey()
+  const ks = await sdk.keystore.get()
+  const { publicKey } = sdk.did.didToPublicKey(didExchange)
+  const readKey = await ks.encrypt(plainTextReadKey, publicKey)
 
   app.ports.gotUcansForApplication.send(
     { readKey, ucans }


### PR DESCRIPTION
## Problem
Read key is being sent plaintext in query params when redirecting back to app

## Solution
Encrypt with the app's exchange key

Closes https://github.com/fission-suite/auth-lobby/issues/18
Related https://github.com/fission-suite/webnative/pull/108