### PR TITLE
Add elm-format to nix shell

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -34,7 +34,7 @@ workbox_config 		:= "workbox.config.cjs"
 	mkdir -p {{dist_dir}}
 
 
-@dev-build: clean css-large elm html js images static apply-config service-worker translate-schemas
+@dev-build: clean css-large translate-schemas elm html js images static apply-config service-worker
 	echo {{config}} &> /dev/null
 
 
@@ -104,11 +104,11 @@ insert-version:
 		-- --compress --mangle
 
 
-@production-build: clean css-large production-elm html css-small js images static minify-js
+@production-build: clean css-large translate-schemas production-elm html css-small js images static minify-js
 	just config=production apply-config production-service-worker
 
 
-@staging-build: clean css-large production-elm html css-small js images static minify-js
+@staging-build: clean css-large translate-schemas production-elm html css-small js images static minify-js
 	just config=default apply-config production-service-worker
 
 

--- a/README.md
+++ b/README.md
@@ -114,9 +114,6 @@ This project uses Nix to manage the project's environment. If you'd like to buil
 # Install javascript dependencies
 just install-deps
 
-# Translate schemas into Elm code
-just translate-schemas
-
 # Build, serve, watch
 just
 

--- a/README.md
+++ b/README.md
@@ -114,6 +114,9 @@ This project uses Nix to manage the project's environment. If you'd like to buil
 # Install javascript dependencies
 just install-deps
 
+# Translate schemas into Elm code
+just translate-schemas
+
 # Build, serve, watch
 just
 

--- a/shell.nix
+++ b/shell.nix
@@ -18,6 +18,7 @@ in
       pkgs.elmPackages.elm
       pkgs.nodejs-14_x
       pkgs.nodePackages.pnpm
+      pkgs.elmPackages.elm-format
 
     ];
   }


### PR DESCRIPTION
Adds `elm-format` to the nix shell and updates the README development instructions with `just translate-schemas`.