### PR TITLE
Fix backwardscompatibility with webnative version <0.24 permission directory paths

### DIFF
--- a/src/Javascript/Main.js
+++ b/src/Javascript/Main.js
@@ -255,9 +255,6 @@ async function linkApp({
   sharedRepo,
   keyInSessionStorage,
 }) {
-  // Both features became available at webnative v0.24.0
-  const supportsFilepathPermissions = keyInSessionStorage
-
   const audience = didWrite
   const issuer = await wn.did.write()
 
@@ -314,7 +311,7 @@ async function linkApp({
     if (!posixPath) return
 
     // Before webnative v0.24.0 we assumed all permission paths to be directory paths
-    if (!posixPath.endsWith("/") && !supportsFilepathPermissions) {
+    if (!posixPath.endsWith("/") && !canPermissionFiles) {
       posixPath += "/"
     }
 
@@ -360,7 +357,7 @@ async function linkApp({
     const pathExists = await fs.exists(path)
 
     if (!pathExists) {
-      if (!canPermissionFiles || wn.path.isDirectory(path)) {
+      if (wn.path.isDirectory(path)) {
         await fs.mkdir(path, { localOnly: true })
       } else {
         await fs.write(path, "", { localOnly: true })

--- a/src/Javascript/Main.js
+++ b/src/Javascript/Main.js
@@ -249,10 +249,15 @@ async function linkApp({
   didExchange,
   attenuation,
   lifetimeInSeconds,
+
+  // webnative version-specific feature flags
   oldFlow,
   sharedRepo,
   keyInSessionStorage,
 }) {
+  // Both features became available at webnative v0.24.0
+  const supportsFilepathPermissions = keyInSessionStorage
+
   const audience = didWrite
   const issuer = await wn.did.write()
 
@@ -305,8 +310,13 @@ async function linkApp({
   const privatePaths = []
 
   att.forEach(a => {
-    const posixPath = a.wnfs || a.floofs
+    let posixPath = a.wnfs || a.floofs
     if (!posixPath) return
+
+    // Before webnative v0.24.0 we assumed all permission paths to be directory paths
+    if (!posixPath.endsWith("/") && !supportsFilepathPermissions) {
+      posixPath += "/"
+    }
 
     const path = wn.path.fromPosix(posixPath)
 


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/1430958/118492016-ddeb8100-b71f-11eb-824a-57defed8455d.png)

After:
![image](https://user-images.githubusercontent.com/1430958/118492081-f3f94180-b71f-11eb-82ca-4442e22f81eb.png)

---

The issue was that before webnative version 0.24, permissions paths were always implicitly converted to directory paths (because you could only permission directory paths). If new apps now try to use permissions for e.g. `fs: { publicPaths: ["Apps"] }` (webnative v.0.23 syntax), that will get turned into the query param `publicPath=Apps`, which doesn't give an indication that this is supposed to be a directory, not a file.

---

There's also something else in here that we should fix I think: If you try to permission e.g. `private/Apps` as a file, but it already exists as a directory, what should the auth lobby do? I think at the moment it'll just share the read key for the directory instead of for the file. But that might confuse webnative, and generally isn't expected.