### PR TITLE
Fix apps concurrently trying to authenticate

### DIFF
--- a/config/local.json
+++ b/config/local.json
@@ -1,0 +1,7 @@
+{
+  "API_ENDPOINT": "https://matheus23.fission.pizza",
+  "DATA_ROOT_DOMAIN": "fission.team",
+
+  "RELAY": "/dns4/node.fission.systems/tcp/4003/wss/p2p/QmVLEz2SxoNiFnuyLpbXsH6SvjPTrHNMU88vCQZyhgBzgw",
+  "SIGNALING_ADDR": "/dns4/webrtc.runfission.com/tcp/443/wss/p2p-webrtc-star/"
+}

--- a/config/pizza.json
+++ b/config/pizza.json
@@ -1,0 +1,7 @@
+{
+  "API_ENDPOINT": "https://matheus23.fission.pizza",
+  "DATA_ROOT_DOMAIN": "fission.team",
+
+  "RELAY": "/dns4/node.fission.systems/tcp/4003/wss/p2p/QmVLEz2SxoNiFnuyLpbXsH6SvjPTrHNMU88vCQZyhgBzgw",
+  "SIGNALING_ADDR": "/dns4/webrtc.runfission.com/tcp/443/wss/p2p-webrtc-star/"
+}

--- a/fission.yaml.pizza
+++ b/fission.yaml.pizza
@@ -1,0 +1,3 @@
+ignore: []
+url: matheus23-auth.fission.pizza
+build: ./build

--- a/src/Javascript/Main.js
+++ b/src/Javascript/Main.js
@@ -432,7 +432,8 @@ async function linkApp({
   let cid = null
 
   if (keyInSessionStorage) {
-    sessionStorage.setItem("encrypted-secrets", classified)
+    sessionStorage.setItem("encrypted-secrets", classified) // backwards compatibility
+    sessionStorage.setItem(`encrypted-secrets-for-${didExchange}`, classified)
   } else if (sharedRepo) {
     cid = await webnative.ipfs.add(classified).then(r => r.cid)
   } else {

--- a/src/Static/Html/Exchange.html
+++ b/src/Static/Html/Exchange.html
@@ -8,7 +8,7 @@
 
   <script>
       window.addEventListener("message", event => {
-        // make sure the message is ment for us
+        // make sure the message is meant for us
         if (event.data && event.data.webnative == null) return
         const secretsKey = event.data && event.data.didExchange ?
           `encrypted-secrets-for-${event.data.didExchange}` :

--- a/src/Static/Html/Exchange.html
+++ b/src/Static/Html/Exchange.html
@@ -8,12 +8,18 @@
 
   <script>
       window.addEventListener("message", event => {
+        const secretsKey = event.data && event.data.didExchange ?
+          `encrypted-secrets-for-${event.data.didExchange}` :
+          "encrypted-secrets" // backwards compatibility
         // Note: Answering the event.source means we basically
         // answer _anyone_ asking us via an iframe.
-        // This is not an issue, because we only ever expose the
-        // "encrypted-secrets" key and well, the secrets are encrypted.
-        event.source.postMessage(sessionStorage.getItem("encrypted-secrets"), event.origin)
-        sessionStorage.removeItem("encrypted-secrets")
+        // This is not an issue because the secrets are encrypted.
+        // We don't share anything besides things prefixed as "encrypted-secrets".
+        event.source.postMessage(sessionStorage.getItem(secretsKey), event.origin)
+
+        // we don't delete the secrets, as the authenticating app might get
+        // interrupted between fetching the secrets & storing them, and therefore
+        // might re-request them.
       })
   </script>
 

--- a/src/Static/Html/Exchange.html
+++ b/src/Static/Html/Exchange.html
@@ -9,7 +9,7 @@
   <script>
       window.addEventListener("message", event => {
         // make sure the message is ment for us
-        if (event.webnative == null) return
+        if (event.data.webnative == null) return
         const secretsKey = event.data && event.data.didExchange ?
           `encrypted-secrets-for-${event.data.didExchange}` :
           "encrypted-secrets" // backwards compatibility

--- a/src/Static/Html/Exchange.html
+++ b/src/Static/Html/Exchange.html
@@ -9,7 +9,7 @@
   <script>
       window.addEventListener("message", event => {
         // make sure the message is ment for us
-        if (event.data.webnative == null) return
+        if (event.data && event.data.webnative == null) return
         const secretsKey = event.data && event.data.didExchange ?
           `encrypted-secrets-for-${event.data.didExchange}` :
           "encrypted-secrets" // backwards compatibility

--- a/src/Static/Html/Exchange.html
+++ b/src/Static/Html/Exchange.html
@@ -8,6 +8,8 @@
 
   <script>
       window.addEventListener("message", event => {
+        // make sure the message is ment for us
+        if (event.webnative == null) return
         const secretsKey = event.data && event.data.didExchange ?
           `encrypted-secrets-for-${event.data.didExchange}` :
           "encrypted-secrets" // backwards compatibility


### PR DESCRIPTION
Originally I thought this was just too much of an edge case to support.
And I weighted this against "exposing as little encrypted data as possible".
But I think that's not a valid concern.

Overriding the data and removing the data leads to far more difficult
bugs and edge cases to handle in webnative than the safety it privides (which is basically 'none').

---

This PR should be backwards-compatible: Old webnative versions which don't send their exchange did with to the `/exchange.html` file will work just fine (except for concurrent authentication issues this PR fixes).