### PR TITLE
Add rosetta nix override

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "https://github.com/nmattia/niv",
         "owner": "nmattia",
         "repo": "niv",
-        "rev": "3cd7914b2c4cff48927e11c216dadfab7d903fe5",
-        "sha256": "1agq4nvbhrylf2s77kb4xhh9k7xcwdwggq764k4jgsbs70py8cw3",
+        "rev": "e0ca65c81a2d7a4d82a189f1e23a48d59ad42070",
+        "sha256": "1pq9nh1d8nn3xvbdny8fafzw87mj7gsmp6pxkdl65w2g18rmcmzx",
         "type": "tarball",
-        "url": "https://github.com/nmattia/niv/archive/3cd7914b2c4cff48927e11c216dadfab7d903fe5.tar.gz",
+        "url": "https://github.com/nmattia/niv/archive/e0ca65c81a2d7a4d82a189f1e23a48d59ad42070.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "nixpkgs": {
@@ -17,10 +17,10 @@
         "homepage": null,
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "fd0daed2e8d590418fc565de70ea6ca47a6d2dcb",
-        "sha256": "0ph7npwvrvccv5spaxhriv8mk9z9cl9c3i456fm207w56vjllqvn",
+        "rev": "a39ee95a86b1fbdfa9edd65f3810b23d82457241",
+        "sha256": "11sk5hz51189g6a5ahq3s1y65145ra8kcgzfjkmrjp1jzn7h68q8",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/fd0daed2e8d590418fc565de70ea6ca47a6d2dcb.tar.gz",
+        "url": "https://github.com/NixOS/nixpkgs/archive/a39ee95a86b1fbdfa9edd65f3810b23d82457241.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     }
 }

--- a/shell.nix
+++ b/shell.nix
@@ -17,6 +17,7 @@
       pkgs.just
       pkgs.watchexec
       pkgs.jq
+      pkgs.niv
 
       # Language Specific
       pkgs.elmPackages.elm

--- a/shell.nix
+++ b/shell.nix
@@ -1,9 +1,12 @@
-let
+{ rosetta ? false }:
+  let
 
-  sources = import ./nix/sources.nix;
-  pkgs = import sources.nixpkgs {};
+    overrides = if rosetta then { system = "x86_64-darwin"; } else {};
 
-in
+    sources = import ./nix/sources.nix;
+    pkgs = import sources.nixpkgs overrides;
+
+  in
 
   pkgs.mkShell {
     buildInputs = [


### PR DESCRIPTION
## Summary

This PR fixes/implements the following **bugs/features**

* [x] Add nix compatibility for M1 macs

The nix shell will not build on machines with the `aarch64` architecture. This change lets us override and use `x86_64`.

## Test plan (required)

On an M1 mac, set up the nix with

```
nix-shell --arg rosetta true
```

Note that your `/etc/nix/nix.conf` will need to contain this line:

```
extra-platforms = x86_64-darwin
```
