### PR TITLE
Update peer connection strategy

### DIFF
--- a/src/Javascript/Worker.js
+++ b/src/Javascript/Worker.js
@@ -131,9 +131,15 @@ const main = async (port) => {
 
 // Try connecting when browser comes online
 self.addEventListener("online", () => {
-  peers.forEach(peer => {
-    tryConnecting(peer)
-  })
+  peers
+    .filter(peer =>
+      !peer.includes("/localhost/") &&
+      !peer.includes("/127.0.0.1/") &&
+      !peer.includes("/0.0.0.0/")
+    )
+    .forEach(peer => {
+      tryConnecting(peer)
+    })
 })
 
 

--- a/src/Javascript/Worker.js
+++ b/src/Javascript/Worker.js
@@ -13,8 +13,26 @@ import { Server, IPFSService } from "ipfs-message-port-server"
 
 self.apiEndpoint = API_ENDPOINT
 
+
+/** 🎛️ Connection interval knobs
+ *
+ * KEEP_ALIVE_INTERVAL: Interval to keep the connection alive when online
+ * BACKOFF_INIT: Starting intervals for fibonacci backoff used when establishing a connection
+ * KEEP_TRYING_INTERVAL: Interval to keep trying the connection when offline
+ */
+
 const KEEP_ALIVE_INTERVAL =
   1 * 60 * 1000 // 1 minute
+
+const BACKOFF_INIT = {
+  retryNumber: 0,
+  lastBackoff: 0,
+  currentBackoff: 1000
+}
+
+const KEEP_TRYING_INTERVAL =
+  5 * 60 * 1000 // 5 minutes
+
 
 const OPTIONS = {
   config: {
@@ -39,6 +57,7 @@ const OPTIONS = {
 let peers = Promise.resolve(
   []
 )
+let latestPeerTimeoutIds = {}
 
 
 importScripts("web_modules/ipfs.min.js")
@@ -85,14 +104,19 @@ const main = async (port) => {
   self.server = server
 
   peers.forEach(peer => {
+    latestPeerTimeoutIds[peer] = null
+  })
+
+  peers.forEach(peer => {
     tryConnecting(peer)
   })
 
   console.log("🚀 Started IPFS node")
 
-  // Monitor bitswap automatically if on localhost and staging environment
+  // Monitor bitswap and peer connections automatically if on localhost and staging environment
   if ([ "localhost", "auth.runfission.net" ].includes(self.location.hostname)) {
     monitorBitswap()
+    await monitorPeers()
   }
 
   // Connect every queued and future connection to the server.
@@ -108,6 +132,17 @@ const main = async (port) => {
 }
 
 
+// Try connecting when browser comes online
+self.addEventListener('online', () => {
+  peers.forEach(peer => {
+    tryConnecting(peer)
+  })
+})
+
+
+// PEERS
+// -----
+
 function fetchPeers() {
   const peersUrl = `${self.apiEndpoint}/ipfs/peers`
 
@@ -118,47 +153,143 @@ function fetchPeers() {
 }
 
 
-async function keepAlive(peer) {
-  const timeoutId = setTimeout(() => reconnect(peer), 30 * 1000)
+// CONNECTIONS
+// -----------
 
-  self.ipfs.libp2p.ping(peer).then(() => {
+async function keepAlive(peer, backoff, status) {
+  let timeoutId = null;
+
+  if (backoff.currentBackoff < KEEP_TRYING_INTERVAL) {
+
+    // Start race between reconnect and ping
+    timeoutId = setTimeout(() => reconnect(peer, backoff, status), backoff.currentBackoff)
+  } else {
+
+    // Disregard backoff, but keep trying
+    timeoutId = setTimeout(() => reconnect(peer, backoff, status), KEEP_TRYING_INTERVAL)
+  }
+
+  // Track the latest reconnect attempt
+  latestPeerTimeoutIds[peer] = timeoutId
+
+  self.ipfs.libp2p.ping(peer).then(latency => {
+    const updatedStatus = { connected: true, lastConnectedAt: Date.now(), latency }
+    report(peer, updatedStatus)
+
+    // Cancel reconnect because ping won
     clearTimeout(timeoutId)
-  }).catch(() => {}).finally(() => {
-    setTimeout(() => keepAlive(peer), KEEP_ALIVE_INTERVAL)
-  })
+
+    // Keep alive after the latest ping-reconnect race, ignore the rest
+    if (timeoutId === latestPeerTimeoutIds[peer]) {
+      setTimeout(() => keepAlive(peer, BACKOFF_INIT, updatedStatus), KEEP_ALIVE_INTERVAL)
+    }
+  }).catch(() => { })
 }
 
 
-async function reconnect(peer) {
-  await self.ipfs.swarm.disconnect(peer)
-  await self.ipfs.swarm.connect(peer)
+async function reconnect(peer, backoff, status) {
+  const updatedStatus = { ...status, connected: false, latency: null }
+  report(peer, updatedStatus)
+
+  try {
+    await self.ipfs.swarm.disconnect(peer)
+    await self.ipfs.swarm.connect(peer)
+  } catch {
+    // No action needed, we will retry
+  }
+
+  if (backoff.currentBackoff < KEEP_TRYING_INTERVAL) {
+    const nextBackoff = {
+      retryNumber: backoff.retryNumber + 1,
+      lastBackoff: backoff.currentBackoff,
+      currentBackoff: backoff.lastBackoff + backoff.currentBackoff
+    }
+
+    keepAlive(peer, nextBackoff, updatedStatus)
+  } else {
+    keepAlive(peer, backoff, updatedStatus)
+  }
 }
 
 
 async function tryConnecting(peer) {
   self
     .ipfs.libp2p.ping(peer)
-    .then(() => {
+    .then(latency => {
+
       return ipfs.swarm
-        .connect(peer, 15 * 1000)
+        .connect(peer, 1 * 1000)
         .then(() => {
           console.log(`🪐 Connected to ${peer}`)
+
+          const status = { connected: true, lastConnectedAt: Date.now(), latency }
+          report(peer, status)
 
           // Ensure permanent connection to Fission gateway
           // TODO: This is a temporary solution while we wait for
           //       https://github.com/libp2p/js-libp2p/issues/744
           //       (see "Keep alive" bit)
-          setTimeout(() => keepAlive(peer), KEEP_ALIVE_INTERVAL)
+          setTimeout(() => keepAlive(peer, BACKOFF_INIT, status), KEEP_ALIVE_INTERVAL)
         })
     })
     .catch(() => {
       console.log(`🪓 Could not connect to ${peer}`)
+
+      const status = { connected: false, lastConnectedAt: 0, latency: null }
+      report(peer, status)
+
+      keepAlive(peer, BACKOFF_INIT, status)
     })
 }
 
 
 self.reconnect = reconnect
 
+
+// REPORTING
+// ---------
+
+let peerConnections = []
+let monitoringPeers = false
+
+function report(peer, status) {
+  peerConnections = peerConnections
+    .filter(connection => connection.peer !== peer)
+    .concat({ peer, ...status })
+
+  const offline = peerConnections.every(connection => !connection.connected)
+  const lastConnectedAt = peerConnections.reduce((newest, connection) =>
+    newest >= connection.lastConnectedAt ? newest : connection.lastConnectedAt,
+    0
+  )
+
+  const activeConnections = peerConnections.filter(connection => connection.latency !== null)
+  const averageLatency = activeConnections.length > 0
+    ? peerConnections.reduce((sum, connection) => sum + connection.latency, 0) / activeConnections.length
+    : null
+
+  if (monitoringPeers) {
+    console.table(peerConnections)
+    console.log('offline', offline)
+    console.log('last connected at', lastConnectedAt === 0 ? null : lastConnectedAt)
+    console.log('average latency', averageLatency)
+  }
+}
+
+
+async function monitorPeers() {
+  monitoringPeers = true 
+  console.log("📡 Monitoring IPFS peers")
+}
+
+
+function stopMonitoringPeers() {
+  monitoringPeers = false
+}
+
+
+self.monitorPeers = monitorPeers
+self.stopMonitoringPeers = stopMonitoringPeers
 
 
 // 🔮
@@ -222,11 +353,11 @@ async function monitorBitswap(verbose) {
 
           if (dag.value.Links) {
             console.log(`🧱 ${c} is a 👉 DAG structure (${loaded})`)
-            ;(console.table || console.log)(
-              dag.value.Links.map(l => {
-                return { name: l.Name, cid: l.Hash.toString() }
-              })
-            )
+              ;(console.table || console.log)(
+                dag.value.Links.map(l => {
+                  return { name: l.Name, cid: l.Hash.toString() }
+                })
+              )
 
           } else {
             console.log(`📦 ${c} is 👉 Data (${loaded})`)

--- a/src/Javascript/Worker.js
+++ b/src/Javascript/Worker.js
@@ -116,7 +116,7 @@ const main = async (port) => {
   // Monitor bitswap and peer connections automatically if on localhost and staging environment
   if ([ "localhost", "auth.runfission.net" ].includes(self.location.hostname)) {
     monitorBitswap()
-    await monitorPeers()
+    monitorPeers()
   }
 
   // Connect every queued and future connection to the server.

--- a/src/Javascript/Worker.js
+++ b/src/Javascript/Worker.js
@@ -105,9 +105,6 @@ const main = async (port) => {
 
   peers.forEach(peer => {
     latestPeerTimeoutIds[peer] = null
-  })
-
-  peers.forEach(peer => {
     tryConnecting(peer)
   })
 

--- a/src/Javascript/Worker.js
+++ b/src/Javascript/Worker.js
@@ -133,7 +133,7 @@ const main = async (port) => {
 
 
 // Try connecting when browser comes online
-self.addEventListener('online', () => {
+self.addEventListener("online", () => {
   peers.forEach(peer => {
     tryConnecting(peer)
   })
@@ -270,9 +270,9 @@ function report(peer, status) {
 
   if (monitoringPeers) {
     console.table(peerConnections)
-    console.log('offline', offline)
-    console.log('last connected at', lastConnectedAt === 0 ? null : lastConnectedAt)
-    console.log('average latency', averageLatency)
+    console.log("offline", offline)
+    console.log("last connected at", lastConnectedAt === 0 ? null : lastConnectedAt)
+    console.log("average latency", averageLatency)
   }
 }
 


### PR DESCRIPTION
## Summary

This PR fixes/implements the following **bugs/features**

* [x] Use Fibonnci backoff for establishing a connection
* [x] Use a keep trying interval when Fibonnaci backoff fails (try every five minutes)
* [x] Attempt to reconnect immediately when coming online
* [x] Add connection status reporting

Our current implementation uses keep alive to reconnect every 60 seconds. With these changes, Fibonacci backoff will attempt to reconnect sooner if a connect attempt fails and backoff gradually. Once we reach a threshhold of five minutes, it no longer makes sense to backoff further and we keep trying every five minutes.

In addition, on an `online` event, we attempt to connect immediately.

We report connection status individually and in aggregate in the console. For each connection we report:

- Peer multiaddress
- `connected` status
- `lastConnectedAt` timestamp
- `latency` in milliseconds

In aggregate, we report

- `offline` status, true when all peers are not connected
- `lastConnectedAt`, the timestamp of the most recent connection to any peer
- average latency across all connected peers

Reporting is on by default on `localhost` and in the staging environment. 

In production, you can start monitoring connections by running `monitorPeers` in the shared worker console and stop monitoring with `stopMonitoringPeers`. The shared worker console is in `about:debugging#/runtime/this-firefox` in Firefox and `chrome://inspect/#workers` in Chrome. (Scroll way down in Firefox to Shared Workers.)

## Test plan (required)

Open the shared worker console and watch the logging to check on the connections. Turn off your WiFi (or unplug Ethernet) to simulate lost connections. The peers should start trying to connect using Fibonacci backoff, often at first then less often. Go back online and the connections should start coming back online immediately.

For finer grained testing and debugging, you can use this proof-of-concept environment: https://github.com/fission-suite/ipfs-connection-poc. The connection strategy was developed there and the implementation should be exactly the same (except not in a service worker, reporting on by default). In the proof-of-concept you can use local IPFS peers, production peers or even combine the to try cases where only some peers aren't available. It also has verbose logging to check backoff times in more detail.