### PR TITLE
Actually detect version mismatches

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -90,7 +90,7 @@ insert-variables:
 	pnpm install
 	rm -rf web_modules
 	mkdir -p web_modules
-	cp ./node_modules/webnative/dist/index.umd.min.js web_modules/webnative.min.js
+	cp -RT node_modules/webnative/dist/ web_modules/webnative/
 
 	just download-web-module localforage.min.js https://cdnjs.cloudflare.com/ajax/libs/localforage/1.9.0/localforage.min.js
 	just download-web-module ipfs.min.js https://unpkg.com/ipfs@0.59.1/index.min.js

--- a/fission.yaml.pizza
+++ b/fission.yaml.pizza
@@ -1,3 +1,0 @@
-ignore: []
-url: matheus23-auth.fission.pizza
-build: ./build

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "ipfs-message-port-server": "0.10.2-rc.2",
     "localforage": "^1.9.0",
     "multiformats": "^9.4.8",
-    "webnative": "0.30.0-alpha5"
+    "webnative": "0.30.0-alpha6"
   },
   "devDependencies": {
     "elm-tailwind-css": "^1.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,7 +13,7 @@ specifiers:
   quicktype: https://ipfs.runfission.com/ipfs/bafybeiet7p4wkt2fmdeyx4n7la5t5jry77yb2xmoxvuuagtsvg4hrdr5hm/p/quicktype-elm.tar.gz
   tailwindcss: ^2.0.3
   terser-dir: ^1.0.7
-  webnative: 0.30.0-alpha5
+  webnative: 0.30.0-alpha6
   workbox-cli: ^6.1.2
   workbox-strategies: ^6.1.2
 
@@ -23,7 +23,7 @@ dependencies:
   ipfs-message-port-server: 0.10.2-rc.2
   localforage: 1.9.0
   multiformats: 9.4.8
-  webnative: 0.30.0-alpha5
+  webnative: 0.30.0-alpha6
 
 devDependencies:
   elm-tailwind-css: 1.1.1_tailwindcss@2.0.3
@@ -6354,8 +6354,8 @@ packages:
     resolution: {integrity: sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==}
     dev: true
 
-  /webnative/0.30.0-alpha5:
-    resolution: {integrity: sha512-1s3lvGwjvB3XYaJnsLu5Cpwt6mjFRfpy3wf0NydzTElZOWpj3FJ3rdOxQQpJqV2yAD2IH43ZYTFI/d1TLaN1dw==}
+  /webnative/0.30.0-alpha6:
+    resolution: {integrity: sha512-qjlKYsWgNINpOQuERXxElsy0WnRKat4dN5eLLFsPvVk8NiWrw1mFcEGUbgCf2ulKT5qLpeXCjG8meh4eIWoaMQ==}
     engines: {node: '>=15'}
     dependencies:
       '@ipld/dag-pb': 2.1.13
@@ -6363,7 +6363,7 @@ packages:
       cids: 1.1.9
       fission-bloom-filters: 1.7.1
       ipfs-message-port-client: 0.9.2-rc.6
-      ipfs-message-port-protocol: 0.10.2-rc.2
+      ipfs-message-port-protocol: 0.10.2
       ipld-dag-pb: 0.22.3
       keystore-idb: 0.15.4
       localforage: 1.10.0

--- a/src/Javascript/Main.js
+++ b/src/Javascript/Main.js
@@ -26,8 +26,8 @@ wn.setup.debug({
 
 wn.setup.userMessages({
   versionMismatch: {
-    newer: async version => alert(`Your auth lobby is outdated. It might be cached. Try reloading the page until this message disappears. If this doesn't help, please contact support@fission.codes. (Filesystem version: ${version}. Webnative version: ${wn.VERSION})`),
-    older: async version => alert(`Your filesystem is outdated. Please upgrade your filesystem by using a miration app or click on "remove this device" and create a new account. (Filesystem version: ${version}. Webnative version: ${wn.VERSION})`),
+    newer: async version => alert(`Your auth lobby is outdated. It might be cached. Try reloading the page until this message disappears.\n\nIf this doesn't help, please contact support@fission.codes.\n\n(Filesystem version: ${version}. Webnative version: ${wn.VERSION})`),
+    older: async version => alert(`Your filesystem is outdated.\n\nPlease upgrade your filesystem by running a miration (https://guide.fission.codes/accounts/account-signup/account-migration) or click on "remove this device" and create a new account.\n\n(Filesystem version: ${version}. Webnative version: ${wn.VERSION})`),
   }
 })
 

--- a/src/Static/Html/Main.html
+++ b/src/Static/Html/Main.html
@@ -32,7 +32,7 @@
 
   <!-- <script defer src="web_modules/ipfs.min.js"></script> -->
   <script defer src="web_modules/localforage.min.js"></script>
-  <script defer src="web_modules/webnative.min.js"></script>
+  <script defer src="web_modules/webnative/index.umd.min.js"></script>
   <script defer src="elm.js"></script>
   <script defer src="index.js"></script>
 

--- a/src/Static/Html/Reset.html
+++ b/src/Static/Html/Reset.html
@@ -30,7 +30,7 @@
 
 
   <script src="../web_modules/localforage.min.js"></script>
-  <script src="../web_modules/webnative.min.js"></script>
+  <script src="../web_modules/webnative/index.umd.min.js"></script>
   <script>
     async function clearData(event) {
       await webnative.keystore.clear()


### PR DESCRIPTION
Even though we've updated the auth lobby to webnative version 0.30.0, the version checks implemented don't actually get run, because the auth lobby is using the file system directly (i.e. `FileSystem.fromCID`), and thus circumvents the `checkFileSystemVerion` check.

This PR
* updates the auth lobby to the latest webnative 0.30 alpha (with some renames + version mismatch checking fixes)
* adds `await wn.checkFileSystemVersion(dataRoot)` calls before working with the data root
* makes it possible to "remove this device" even if the auth lobby can't remove the well-known exchange key, because it can't work with that file system version
* adjusts the migration messages to link to the guide on migration

The current staging shouldn't land on production. With this PR I think it could be ready :)