### PR TITLE
Fix IPFS Safari issue

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -92,8 +92,8 @@ insert-variables:
 	mkdir -p web_modules
 	cp -RT node_modules/webnative/dist/ web_modules/webnative/
 
-	just download-web-module localforage.min.js https://cdnjs.cloudflare.com/ajax/libs/localforage/1.9.0/localforage.min.js
-	just download-web-module ipfs.min.js https://unpkg.com/ipfs@0.59.1/index.min.js
+	just download-web-module localforage.min.js https://cdnjs.cloudflare.com/ajax/libs/localforage/1.10.0/localforage.min.js
+	just download-web-module ipfs.min.js https://unpkg.com/ipfs@0.61.0/index.min.js
 
 
 @js:

--- a/package.json
+++ b/package.json
@@ -3,11 +3,11 @@
   "type": "module",
   "dependencies": {
     "@fission-suite/kit": "2.1.0",
-    "ipfs-message-port-protocol": "0.10.2-rc.2",
-    "ipfs-message-port-server": "0.10.2-rc.2",
+    "ipfs-message-port-protocol": "^0.10.5",
+    "ipfs-message-port-server": "^0.10.5",
     "localforage": "^1.9.0",
     "multiformats": "^9.4.8",
-    "webnative": "0.30.0-alpha8"
+    "webnative": "0.30.0-alpha12"
   },
   "devDependencies": {
     "elm-tailwind-css": "^1.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,10 +1,10 @@
 dependencies:
   '@fission-suite/kit': 2.1.0
-  ipfs-message-port-protocol: 0.10.2-rc.2
-  ipfs-message-port-server: 0.10.2-rc.2
+  ipfs-message-port-protocol: 0.10.5
+  ipfs-message-port-server: 0.10.5
   localforage: 1.9.0
   multiformats: 9.4.8
-  webnative: 0.30.0-alpha8
+  webnative: 0.30.0-alpha12
 devDependencies:
   elm-tailwind-css: 1.1.1_tailwindcss@2.0.3
   esbuild: 0.12.29
@@ -3286,29 +3286,20 @@ packages:
       node: '>=8'
     resolution:
       integrity: sha512-B9ZWJxHHOHUhUjCPrMpLD4xEq35bUTClHM1S6CBU5ixQnkZmwipwgc96vAd7AAGM9TGHvJR+Uss+/Ak6UphK+Q==
-  /ipfs-core-types/0.8.2-rc.2:
-    dependencies:
-      interface-datastore: 6.0.3
-      multiaddr: 10.0.1
-      multiformats: 9.4.4
-    dev: false
-    resolution:
-      integrity: sha512-N4F5BY5CmjVYDAvvhVuXWWpaneLNZLZqYHKdMe1HFuBy3YBXU49jWHWlBLfcoZWydTg5fmHxiigO1VwQBgaLrg==
-      tarball: ipfs-core-types/-/ipfs-core-types-0.8.2-rc.2.tgz
-  /ipfs-core-types/0.8.4:
+  /ipfs-core-types/0.9.0:
     dependencies:
       interface-datastore: 6.0.3
       multiaddr: 10.0.1
       multiformats: 9.5.4
     dev: false
     resolution:
-      integrity: sha512-sbRZA1QX3xJ6ywTiVQZMOxhlhp4osAZX2SXx3azOLxAtxmGWDMkHYt722VV4nZ2GyJy8qyk5GHQIZ0uvQnpaTg==
-  /ipfs-message-port-client/0.9.2-rc.6:
+      integrity: sha512-VJ8vJSHvI1Zm7/SxsZo03T+zzpsg8pkgiIi5hfwSJlsrJ1E2v68QPlnLshGHUSYw89Oxq0IbETYl2pGTFHTWfg==
+  /ipfs-message-port-client/0.10.3:
     dependencies:
       browser-readablestream-to-it: 1.0.3
       err-code: 3.0.1
-      ipfs-core-types: 0.8.4
-      ipfs-message-port-protocol: 0.10.4
+      ipfs-core-types: 0.9.0
+      ipfs-message-port-protocol: 0.10.5
       ipfs-unixfs: 6.0.6
       it-peekable: 1.0.3
       multiformats: 9.5.4
@@ -3317,41 +3308,29 @@ packages:
       node: '>=14.0.0'
       npm: '>=3.0.0'
     resolution:
-      integrity: sha512-yNWx6yXUN9OuYvCZMXvvCSCkyofjAZpBHDP5qrjbsznwBG3LavdXlWKnw4ou090zB8W0tmmq3UFIejLUYewa0A==
-  /ipfs-message-port-protocol/0.10.2-rc.2:
+      integrity: sha512-lAdIdU8fpZBGUg1dG22X55Qnm3N6BxEVf4d3tYu8ITaIxhrZ2nm2HmkNzlc5fYeIZKTICThIDYiqzqMTrx67aw==
+  /ipfs-message-port-protocol/0.10.5:
     dependencies:
-      ipfs-core-types: 0.8.2-rc.2
-      multiformats: 9.4.4
-    dev: false
-    engines:
-      node: '>=14.0.0'
-      npm: '>=3.0.0'
-    resolution:
-      integrity: sha512-tbaHJpryBBuMKMkp+5Gj4fD6YiPGfqAc4fSsjvEg+aVVSMhRAdnD8d/wfPquCwHZxrcUUuNVjsCioXeG9kFVdg==
-      tarball: ipfs-message-port-protocol/-/ipfs-message-port-protocol-0.10.2-rc.2.tgz
-  /ipfs-message-port-protocol/0.10.4:
-    dependencies:
-      ipfs-core-types: 0.8.4
+      ipfs-core-types: 0.9.0
       multiformats: 9.5.4
     dev: false
     engines:
       node: '>=14.0.0'
       npm: '>=3.0.0'
     resolution:
-      integrity: sha512-zr5qfyCQpStE+E6y7is5WrG6PiiCgtjBlNsSpEAzllYC8NA1iKsm9GJJX924B+cuY6k4lBaSotozgnjbrIBpAA==
-  /ipfs-message-port-server/0.10.2-rc.2:
+      integrity: sha512-dHq+N0Epur5k7ZnQTSOepp5/Gmvtrg8SCD65t2okthkP8c4xIVxxaMpXZbHgi/2x0ix7HoQt4QiQa0StMkoj7A==
+  /ipfs-message-port-server/0.10.5:
     dependencies:
-      ipfs-core-types: 0.8.2-rc.2
-      ipfs-message-port-protocol: 0.10.2-rc.2
+      ipfs-core-types: 0.9.0
+      ipfs-message-port-protocol: 0.10.5
       it-all: 1.0.5
-      multiformats: 9.4.4
+      multiformats: 9.5.4
     dev: false
     engines:
       node: '>=14.0.0'
       npm: '>=3.0.0'
     resolution:
-      integrity: sha512-jxF6dOUnL2cqvhIvz1ou2mKRp3FpMLK2KvYMSm6kMyZV1tBGcS+D+ZV9GZ9orDaf808zKPeiPTPDR1cieJSSmA==
-      tarball: ipfs-message-port-server/-/ipfs-message-port-server-0.10.2-rc.2.tgz
+      integrity: sha512-vPCqfv8h29VWYGFEL4arbVp+Yp0uR/xmdvmSHpB0F8e8QUGsl4gowA7k8jefhQUMWc5J7q66g18NmFafhKhLaQ==
   /ipfs-unixfs/6.0.6:
     dependencies:
       err-code: 3.0.1
@@ -4353,18 +4332,10 @@ packages:
     dev: false
     resolution:
       integrity: sha512-+expTPftro8VAW8kfvcuNNNBgb9gPeNYV9dn+z1kJRWF2vih+/S79f2RVeIwmrJBUJ6NT9IUPWnZDQvegEh5pw==
-  /multiformats/9.4.4:
-    dev: false
-    resolution:
-      integrity: sha512-lGAP3Cuc4nHRq5q9EQZFGegXBlElmlfcz7d2xsDO/u4TG7M2kkdsGOaZPe9FIbfWugWPx643VTXgZctqqJfTzg==
   /multiformats/9.4.8:
     dev: false
     resolution:
       integrity: sha512-EOJL02/kv+FD5hoItMhKgkYUUruJYMYFq4NQ6YkCh3jVQ5CuHo+OKdHeR50hAxEQmXQ9yvrM9BxLIk42xtfwnQ==
-  /multiformats/9.5.2:
-    dev: false
-    resolution:
-      integrity: sha512-nLQ9s7YOVtZdeNOVvCkNyFiZdS3wyq0gvCIvdm7Zy1zw3zBoColJKjMkIPXNdTqT7ruuq+G7HrezIN0cXiAZ0w==
   /multiformats/9.5.4:
     dev: false
     resolution:
@@ -6774,19 +6745,19 @@ packages:
     dev: true
     resolution:
       integrity: sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==
-  /webnative/0.30.0-alpha8:
+  /webnative/0.30.0-alpha12:
     dependencies:
       '@ipld/dag-cbor': 6.0.15
       '@ipld/dag-pb': 2.1.15
       cborg: 1.5.4
       cids: 1.1.9
       fission-bloom-filters: 1.7.1
-      ipfs-message-port-client: 0.9.2-rc.6
-      ipfs-message-port-protocol: 0.10.2-rc.2
+      ipfs-message-port-client: 0.10.3
+      ipfs-message-port-protocol: 0.10.5
       ipld-dag-pb: 0.22.3
       keystore-idb: 0.15.4
-      localforage: 1.9.0
-      multiformats: 9.5.2
+      localforage: 1.10.0
+      multiformats: 9.5.4
       one-webcrypto: 1.0.3
       throttle-debounce: 3.0.1
       tweetnacl: 0.14.5
@@ -6795,7 +6766,7 @@ packages:
     engines:
       node: '>=15'
     resolution:
-      integrity: sha512-mFiUEfb+uEEKZgHIc+FSQMVPWEIlUMma/THp9gh8H1Yy43tFOW+16doM+yLlbjbYNqCMUfam9lJ5PYsIjGGyOQ==
+      integrity: sha512-toSFIz7fX72XWa8QVQmrR3zQ6PNVER2RHhZni6koTQbp70Q+Y4Wapn3zdEhop7/mhWcfQ9xrQMiaTYV1wyAHQg==
   /whatwg-fetch/3.6.2:
     dev: true
     resolution:
@@ -7182,8 +7153,8 @@ specifiers:
   '@fission-suite/kit': 2.1.0
   elm-tailwind-css: ^1.1.1
   esbuild: ^0.12.26
-  ipfs-message-port-protocol: 0.10.2-rc.2
-  ipfs-message-port-server: 0.10.2-rc.2
+  ipfs-message-port-protocol: ^0.10.5
+  ipfs-message-port-server: ^0.10.5
   localforage: ^1.9.0
   multiformats: ^9.4.8
   mustache: ^4.0.1
@@ -7191,6 +7162,6 @@ specifiers:
   quicktype: 'https://ipfs.runfission.com/ipfs/bafybeiet7p4wkt2fmdeyx4n7la5t5jry77yb2xmoxvuuagtsvg4hrdr5hm/p/quicktype-elm.tar.gz'
   tailwindcss: ^2.0.3
   terser-dir: ^1.0.7
-  webnative: 0.30.0-alpha8
+  webnative: 0.30.0-alpha12
   workbox-cli: ^6.1.2
   workbox-strategies: ^6.1.2

--- a/src/Javascript/Worker.js
+++ b/src/Javascript/Worker.js
@@ -14,6 +14,12 @@ import { Server, IPFSService } from "ipfs-message-port-server"
 self.apiEndpoint = API_ENDPOINT
 
 
+// Global state
+let peers = Promise.resolve([])
+const latestPeerTimeoutIds = {}
+const isSafari = /^((?!chrome|android).)*safari/i.test(navigator.userAgent)
+
+
 /** 🎛️ Connection interval knobs
  *
  * KEEP_ALIVE_INTERVAL: Interval to keep the connection alive when online
@@ -34,6 +40,10 @@ const KEEP_TRYING_INTERVAL =
   5 * 60 * 1000 // 5 minutes
 
 
+
+/** 🎛️ IPFS Options
+ */
+
 const OPTIONS = {
   config: {
     Addresses: {
@@ -51,13 +61,11 @@ const OPTIONS = {
     config: {
       peerDiscovery: { autoDial: false }
     }
+  },
+  init: {
+    algorithm: isSafari ? "RSA" : undefined
   }
 }
-
-let peers = Promise.resolve(
-  []
-)
-let latestPeerTimeoutIds = {}
 
 
 importScripts("web_modules/ipfs.min.js")
@@ -281,7 +289,7 @@ function report(peer, status) {
 
 
 async function monitorPeers() {
-  monitoringPeers = true 
+  monitoringPeers = true
   console.log("📡 Monitoring IPFS peers")
 }
 


### PR DESCRIPTION
Fixes:

<img width="995" alt="Screenshot 2022-01-18 at 16 58 20" src="https://user-images.githubusercontent.com/296665/150017660-fec8dc47-3aed-4641-a484-90a08d5691cb.png">

Also:
- Bumps webnative to latest alpha
- Bumps js-ipfs to the latest release
- Upgrades to latest message-port releases, moving away from the release candidates